### PR TITLE
Update regress

### DIFF
--- a/Hello World/regress.py
+++ b/Hello World/regress.py
@@ -1,18 +1,36 @@
-# by shane#9837 (Discord)
-
+"""
+    Original module written by shane#9837 (on Discord).
+"""
 import vapoursynth as vs
-from collections import namedtuple
 from functools import partial
-from typing import Callable
+from typing import NamedTuple
+core = vs.core
 
-RegressParams = namedtuple('RegressParams', 'slope intercept correlation')
+class RegressClips(NamedTuple):
+    slope: vs.VideoNode
+    intercept: vs.VideoNode
+    correlation: vs.VideoNode
 
 
 def Regress(x, *ys, radius=1, eps=1e-7):
+    """
+    Fit a line for every neighborhood of values of a given size in a clip
+    with corresponding neighborhoods in one or more other clips.
+
+    More info: https://en.wikipedia.org/wiki/Simple_linear_regression
+    """
+
+    if not radius > 0:
+        raise ValueError("radius must be greater than zero")
+
     Expr = vs.core.std.Expr
-    mul = lambda *c: Expr(c, 'x y *')
-    sq = lambda c: mul(c, c)
     E = partial(vs.core.std.BoxBlur, hradius=radius, vradius=radius)
+
+    def mul(*c):
+        return Expr(c, "x y *")
+
+    def sq(c):
+        return mul(c, c)
 
     Ex = E(x)
     Exx = E(sq(x))
@@ -20,41 +38,25 @@ def Regress(x, *ys, radius=1, eps=1e-7):
     Exys = [E(mul(x, y)) for y in ys]
     Eyys = [E(sq(y)) for y in ys]
 
-    var_x = Expr((Exx, Ex), 'x y dup * -')
-    var_ys = [Expr((Eyy, Ey), 'x y dup * -') for Eyy, Ey in zip(Eyys, Eys)]
-    cov_xys = [Expr((Exy, Ex, Ey), 'x y z * -')  for Exy, Ey in zip(Exys, Eys)]
+    var_x = Expr((Exx, Ex), "x y dup * - 0 max")
+    var_ys = [Expr((Eyy, Ey), "x y dup * - 0 max") for Eyy, Ey in zip(Eyys, Eys)]
+    cov_xys = [Expr((Exy, Ex, Ey), "x y z * -") for Exy, Ey in zip(Exys, Eys)]
 
-    slopes = [Expr((cov_xy, var_x), f'x y {eps} + /') 
-              for cov_xy in cov_xys]
-    intercepts = [Expr((Ey, slope, Ex), 'x y z * -') 
-                  for Ey, slope in zip(Eys, slopes)]
-    corrs = [Expr((cov_xy, var_x, var_y), f'x dup * y z * {eps} + / sqrt')
-             for cov_xy, var_y in zip(cov_xys, var_ys)]
+    slopes = [Expr((cov_xy, var_x), f"x y {eps} + /") for cov_xy in cov_xys]
+    intercepts = [Expr((Ey, slope, Ex), "x y z * -") for Ey, slope in zip(Eys, slopes)]
+    corrs = [
+        Expr((cov_xy, var_x, var_y), f"x dup * y z * {eps} + / sqrt")
+        for cov_xy, var_y in zip(cov_xys, var_ys)
+    ]
 
-    return list(map(RegressParams._make, zip(slopes, intercepts, corrs)))
+    return list(map(RegressClips._make, zip(slopes, intercepts, corrs)))
 
+def ReconstructMulti(c, r, radius=2):
+    weights = core.std.Expr(r.correlation, 'x 0.5 - 0.5 / 0 max')
+    slope_pm = core.std.Expr((r.slope, weights), 'x y *')
+    slope_pm_sum = mean(slope_pm, radius)
+    recons = core.std.Expr((c, slope_pm_sum), 'x y *')
+    return recons
 
-def Reconstruct(original_luma: vs.VideoNode, demangled_luma: vs.VideoNode,
-                demangled_chroma_u: vs.VideoNode, demangled_chroma_v: vs.VideoNode,
-                radius: int = 3, use_binary: bool = False) -> vs.VideoNode:
-
-    yu, yv = Regress(demangled_luma, demangled_chroma_u, demangled_chroma_v, radius=radius)
-
-    y_fixup = vs.core.std.MakeDiff(original_luma, demangled_luma)
-
-    if use_binary:
-        u_fixup = vs.core.dpriv.Reconstruct(y_fixup, yu.slope, yu.correlation, radius=radius)
-        v_fixup = vs.core.dpriv.Reconstruct(y_fixup, yv.slope, yv.correlation, radius=radius)
-        u_r = vs.core.std.MergeDiff(demangled_chroma_u, u_fixup)
-        v_r = vs.core.std.MergeDiff(demangled_chroma_v, v_fixup)
-    else:
-        u_fixup = vs.core.std.Expr((y_fixup, yu.slope), 'x y *')
-        u_r = vs.core.std.MergeDiff(demangled_chroma_u, u_fixup)
-        mask_u = vs.core.std.Expr(yu.correlation, 'x 0.3 - 0.7 / dup 0 > swap 0 ?')
-        u_r = vs.core.std.MaskedMerge(demangled_chroma_u, u_r, mask_u)
-        v_fixup = vs.core.std.Expr((y_fixup, yv.slope), 'x y *')
-        v_r = vs.core.std.MergeDiff(demangled_chroma_v, v_fixup)
-        mask_v = vs.core.std.Expr(yv.correlation, 'x 0.3 - 0.7 / dup 0 > swap 0 ?')
-        v_r = vs.core.std.MaskedMerge(demangled_chroma_v, v_r, mask_v)
-
-    return vs.core.std.ShufflePlanes([original_luma.resize.Bicubic(format=vs.GRAY8), u_r.resize.Bicubic(format=vs.GRAY8), v_r.resize.Bicubic(format=vs.GRAY8)], [0,0,0], vs.YUV)
+def mean(c, radius):
+    return core.std.BoxBlur(c, hradius=radius, vradius=radius)


### PR DESCRIPTION
This is the latest version that fixes an annoying issue with NaN values getting returned from BoxBlur, creating this kind of artifacting in the process:

![vlcsnap-2021-01-15-11h59m56s](https://user-images.githubusercontent.com/42927908/105185153-7ede7c80-5b30-11eb-9b01-fabc4f4dbe16.png)
![vlcsnap-2021-01-08-06h00m01s](https://user-images.githubusercontent.com/42927908/105185160-800fa980-5b30-11eb-8a0a-12d035e254b0.png)

Ideally I didn't really wanna update this since imo it's something the original author should release, but I'd rather see a fixed version out in the wild than one that potentially breaks.
